### PR TITLE
Update MermaidsBrushBlock.java

### DIFF
--- a/src/main/java/de/dafuqs/spectrum/blocks/conditional/MermaidsBrushBlock.java
+++ b/src/main/java/de/dafuqs/spectrum/blocks/conditional/MermaidsBrushBlock.java
@@ -157,7 +157,7 @@ public class MermaidsBrushBlock extends PlantBlock implements Fertilizable, Reve
 		float chance = state.get(LOGGED) == FluidLogging.State.LIQUID_CRYSTAL ? 1.0F : 0.5F;
 		int nextAge = age + random.nextBetween(1, (int) Math.ceil(attempts * chance));
 		
-		if (nextAge >= 7) {
+		if (nextAge >= 8) {
 			ItemEntity pearlEntity = new ItemEntity(world, pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5, new ItemStack(SpectrumItems.MERMAIDS_GEM, 1));
 			world.spawnEntity(pearlEntity);
 		}


### PR DESCRIPTION
This is a strange but simple bug,When normally getting random ticked,MermaidsBrush should spawn item when the age 'technically reach 8'(7+1),but it will spawn item when the age reachs 7,7 % 8 is still 7 but it will drop a gem.So sometimes it will drop gems if a bone meal made it age=7,and drop again when it grows again.